### PR TITLE
Add dummy heartbeat file, so that 200 is always returned.

### DIFF
--- a/conf/local.Caddyfile
+++ b/conf/local.Caddyfile
@@ -1,0 +1,8 @@
+# A local mock CDN to proxy requests to the Minio (S3) server.
+# Mimics AWS CloudFront, and removes the bucket path from the URL.
+# e.g. Request: http://archive.intranet.docker/intranet.justice.gov.uk/hmcts/2024-12-13/index.html
+# proxies to  : http://minio:9000/bucket-name/intranet.justice.gov.uk/hmcts/2024-12-13/index.html
+
+:2019
+rewrite * /{$S3_BUCKET_NAME}{uri}
+reverse_proxy minio:9000

--- a/conf/node/constants.js
+++ b/conf/node/constants.js
@@ -66,3 +66,9 @@ export const sensitiveFiles = [
   `hts-cache/doit.log`, // Has the httrack command line arguments - this includes the JWT.
   `hts-cache/new.zip`,
 ];
+
+/**
+ * Intranet application
+ */
+
+export const heartbeatEndpoint = "auth/heartbeat";

--- a/conf/node/controllers/main.js
+++ b/conf/node/controllers/main.js
@@ -8,7 +8,7 @@ import {
   getHttrackProgress,
   waitForHttrackComplete,
 } from "./httrack.js";
-import { sync } from "./s3.js";
+import { createHeartbeat, sync } from "./s3.js";
 
 /**
  *
@@ -47,6 +47,9 @@ export const main = async ({ url, agency, depth }) => {
   await Promise.all(
     sensitiveFiles.map((file) => fs.rm(`${paths.fs}/${file}`, { force: true })),
   );
+
+  // Add a file at /auth/heartbeat for the intranet's heartbeat script.
+  await createHeartbeat();
 
   // Sync the snapshot to S3
   await sync(paths.fs, `s3://${s3BucketName}/${paths.s3}`);

--- a/conf/node/controllers/main.test.js
+++ b/conf/node/controllers/main.test.js
@@ -92,6 +92,24 @@ describe("main", () => {
     expect(pathExists).toBe(false);
   }, 10_000);
 
+  it("should create an auth/heartbeat file", async () => {
+    await main({ url, agency, depth: 1 });
+
+    // The snapshot should be on s3
+    const objects = await s3Client.send(
+      new ListObjectsV2Command({
+        Bucket: s3BucketName,
+        Prefix: 'auth/heartbeat',
+      }),
+    );
+
+    const heartbeat = objects.Contents.find(
+      (object) => object.Key === 'auth/heartbeat',
+    );
+
+    expect(heartbeat).toBeDefined();
+  }, 10_000);
+
   /**
    * Long running tests...
    */

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,9 +35,6 @@ services:
     environment:
       MINIO_ROOT_USER: ${AWS_ACCESS_KEY_ID}
       MINIO_ROOT_PASSWORD: ${AWS_SECRET_ACCESS_KEY}
-      # Accessible at this domain, so we can manually check that CloudFront cookies have been set correctly.
-      VIRTUAL_HOST: archive.intranet.docker
-      VIRTUAL_PORT: "9001"
     command: server --console-address ":9001" /data
     healthcheck:
       test: timeout 5s bash -c ':> /dev/tcp/127.0.0.1/9000' || exit 1
@@ -58,3 +55,14 @@ services:
         mc anonymous set download intranet-archive/${S3_BUCKET_NAME};
         exit 0
       "
+
+  cdn:
+    image: caddy:2-alpine
+    volumes:
+      - ./conf/local.Caddyfile:/etc/caddy/Caddyfile
+    environment:
+      S3_BUCKET_NAME: ${S3_BUCKET_NAME}
+      VIRTUAL_HOST: archive.intranet.docker
+      VIRTUAL_PORT: 2019
+    depends_on:
+      - minio


### PR DESCRIPTION
This PR adds a dummy heartbeat file, so the the AJAX heartbeat request always returns a 200 status code.

It also adds a caddy server to act as a mock CDN, similar to Justice UK, so that the archives can be browsed locally for testing.