### PR TITLE
CDPT-2295 Rollout snapshot schedule for all agencies

### DIFF
--- a/conf/node/constants.js
+++ b/conf/node/constants.js
@@ -79,7 +79,9 @@ export const allowedTargetHosts = Object.values(intranetUrls).map(
 );
 
 export const allowedTargetAgencies =
-  process.env.ALLOWED_AGENCIES?.split(",") ?? [];
+  process.env.ALLOWED_AGENCIES?.split(",")
+    ?.map((agency) => agency.trim())
+    ?.filter((agency) => agency?.length) ?? [];
 
 /**
  * Schedule

--- a/conf/node/controllers/schedule.js
+++ b/conf/node/controllers/schedule.js
@@ -13,6 +13,7 @@ export const parseScheduleString = (scheduleString) => {
   const scheduleArray = scheduleString?.split(",") ?? [];
 
   return scheduleArray
+    .map((schedule) => schedule.trim())
     .filter((schedule) => schedule?.length)
     .map((schedule) => {
       const [env, agency, dayOfWeek, timeString, optionalDepth] =

--- a/conf/node/controllers/schedule.test.js
+++ b/conf/node/controllers/schedule.test.js
@@ -37,6 +37,31 @@ describe("parseScheduleString", () => {
     ]);
   });
 
+  it("should handle spaces in the schedule string", () => {
+    const scheduleString =
+      "dev::hq::Mon::17:30::1, production::hmcts::Tue::17:30";
+
+    const result = parseScheduleString(scheduleString);
+
+    expect(result).toEqual([
+      {
+        env: "dev",
+        agency: "hq",
+        dayIndexes: [1],
+        hour: 17,
+        min: 30,
+        depth: 1,
+      },
+      {
+        env: "production",
+        agency: "hmcts",
+        dayIndexes: [2],
+        hour: 17,
+        min: 30,
+      },
+    ]);
+  });
+
   it("should throw an error for an invalid environment", () => {
     const scheduleString = "preprod::hq::Mon::17:30";
 

--- a/deploy/development/config.yml
+++ b/deploy/development/config.yml
@@ -4,6 +4,10 @@ metadata:
   name: intranet-archive-dev-config
   namespace: intranet-archive-dev
 data:
-  ALLOWED_AGENCIES: "hq,hmcts"
-  SNAPSHOT_SCHEDULE_00: "dev::hmcts::Thu::17:30::3"
-  SNAPSHOT_SCHEDULE_01: "dev::hq::Mon::17:30::3"
+  ALLOWED_AGENCIES: >-
+    hq,
+    hmcts
+  SNAPSHOT_SCHEDULE_00: >-
+    dev::hmcts::Thu::17:30::3
+  SNAPSHOT_SCHEDULE_01: >-
+    dev::hq::Mon::17:30::3

--- a/deploy/production/config.yml
+++ b/deploy/production/config.yml
@@ -10,6 +10,7 @@ data:
     hq,
     jac,
     judicial-office,
+    laa,
     law-commission,
     opg,
     ospt
@@ -23,3 +24,6 @@ data:
     production::jac::Wed::16:45,
     production::judicial-office::Fri::16:45,
     production::law-commission::Sat::16:45
+  SNAPSHOT_SCHEDULE_02: >-
+    production::laa::Wed::16:45
+

--- a/deploy/production/config.yml
+++ b/deploy/production/config.yml
@@ -4,6 +4,22 @@ metadata:
   name: intranet-archive-production-config
   namespace: intranet-archive-production
 data:
-  ALLOWED_AGENCIES: "hmcts,hq,jac"
-  SNAPSHOT_SCHEDULE_00: "production::hmcts::Mon::15:25"
-  SNAPSHOT_SCHEDULE_01: "production::jac::Wed::16:45"
+  ALLOWED_AGENCIES: >-
+    cica,
+    hmcts,
+    hq,
+    jac,
+    judicial-office,
+    law-commission,
+    opg,
+    ospt
+  SNAPSHOT_SCHEDULE_00: >-
+    production::hmcts::Mon::16:45,
+    production::opg::Wed::16:45,
+    production::ospt::Fri::16:45,
+    production::hq::Sat::16:45
+  SNAPSHOT_SCHEDULE_01: >-
+    production::cica::Mon::16:45,
+    production::jac::Wed::16:45,
+    production::judicial-office::Fri::16:45,
+    production::law-commission::Sat::16:45

--- a/deploy/production/config.yml
+++ b/deploy/production/config.yml
@@ -26,4 +26,3 @@ data:
     production::law-commission::Sat::16:45
   SNAPSHOT_SCHEDULE_02: >-
     production::laa::Wed::16:45
-

--- a/deploy/production/stateful-set.tpl.yml
+++ b/deploy/production/stateful-set.tpl.yml
@@ -3,7 +3,7 @@ kind: StatefulSet
 metadata:
   name: ${KUBE_NAMESPACE}
 spec:
-  replicas: 2
+  replicas: 3
   revisionHistoryLimit: 5
   updateStrategy:
     type: RollingUpdate

--- a/deploy/staging/config.yml
+++ b/deploy/staging/config.yml
@@ -4,6 +4,9 @@ metadata:
   name: intranet-archive-staging-config
   namespace: intranet-archive-staging
 data:
-  ALLOWED_AGENCIES: "hmcts,hq,jac"
-  SNAPSHOT_SCHEDULE_00: "staging::hmcts::Tue::14:45"
-  SNAPSHOT_SCHEDULE_01: "staging::jac::Tue::16:45::3"
+  ALLOWED_AGENCIES: >-
+    hmcts,hq,jac
+  SNAPSHOT_SCHEDULE_00: >-
+    staging::hmcts::Tue::14:45
+  SNAPSHOT_SCHEDULE_01: >-
+    staging::jac::Tue::16:45::3


### PR DESCRIPTION
This PR adds a scheduled date and time to start snapshots for all agencies.

Time windows have been intentionally left empty to allow for deployments without interrupting a running snapshot.

i.e.

- before 16:45 on Mon, Wed & Fri
- all day Tue & Thu

Snapshot times have been set to 16:45 to allow for developers to review logs in real time, towards the end of a working day.

Please do feedback if you have any views on the timings :)